### PR TITLE
fix: stack pointer corruption and ARM64 Docker support

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -107,21 +107,37 @@ steps:
         gh release upload "$VERSION" ./release-assets/*.zip --clobber
     depends_on: [release]
 
-  - name: docker
-    image: gcr.io/kaniko-project/executor:debug
+  - name: docker-prep
+    image: alpine
     when:
       - evaluate: 'CI_COMMIT_MESSAGE not contains "chore(version):"'
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
     commands:
-      - VERSION=$(wget -qO- https://api.github.com/repos/barryw/sim6502/releases/latest | sed -n 's/.*"tag_name".*"v\([^"]*\)".*/\1/p')
-      - echo "Building version $VERSION"
-      # Update version in csproj before building (in case post_bump_hook didn't work)
-      - sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
-      - sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
-      - sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
-      - mkdir -p /kaniko/.docker
-      - echo "{\"auths\":{\"ghcr.io\":{\"username\":\"barryw\",\"password\":\"$GITHUB_TOKEN\"}}}" > /kaniko/.docker/config.json
-      - /kaniko/executor --context="$CI_WORKSPACE" --dockerfile="$CI_WORKSPACE/Dockerfile" --destination="ghcr.io/barryw/sim6502:v$VERSION" --destination="ghcr.io/barryw/sim6502:latest"
+      - apk add --no-cache wget sed
+      - |
+        VERSION=$(wget -qO- https://api.github.com/repos/barryw/sim6502/releases/latest | sed -n 's/.*"tag_name".*"v\([^"]*\)".*/\1/p')
+        if [ -z "$VERSION" ]; then
+          echo "No release found — skipping Docker build"
+          exit 0
+        fi
+        echo "Building Docker image for v$VERSION"
+        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
+        sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
+        sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
+        printf "v%s,latest" "$VERSION" > .tags
     depends_on: [release]
+
+  - name: docker
+    image: woodpeckerci/plugin-docker-buildx:5
+    privileged: true
+    when:
+      - evaluate: 'CI_COMMIT_MESSAGE not contains "chore(version):"'
+    settings:
+      repo: ghcr.io/barryw/sim6502
+      registry: ghcr.io
+      username: barryw
+      password:
+        from_secret: github_token
+      platforms: linux/amd64,linux/arm64
+      auto_tag: false
+      tags_file: .tags
+    depends_on: [docker-prep]

--- a/sim6502/Proc/Processor.Core.cs
+++ b/sim6502/Proc/Processor.Core.cs
@@ -97,15 +97,7 @@ public partial class Processor
     public int StackPointer
     {
         get => _stackPointer;
-        set
-        {
-            if (value > 0xFF)
-                _stackPointer = value - 0x100;
-            else if (value < 0x00)
-                _stackPointer = value + 0x100;
-            else
-                _stackPointer = value;
-        }
+        set => _stackPointer = value & 0xFF;
     }
 
     /// <summary>

--- a/sim6502/Proc/Processor.Execution.cs
+++ b/sim6502/Proc/Processor.Execution.cs
@@ -275,7 +275,7 @@ namespace sim6502.Proc
         private byte PeekStack()
         {
             //The stack lives at 0x100-0x1FF, but the value is only a byte so it needs to be translated
-            return Memory[StackPointer + 0x100];
+            return Memory[(_stackPointer & 0xFF) + 0x100];
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace sim6502.Proc
         private void PokeStack(byte value)
         {
             //The stack lives at 0x100-0x1FF, but the value is only a byte so it needs to be translated
-            Memory[StackPointer + 0x100] = value;
+            Memory[(_stackPointer & 0xFF) + 0x100] = value;
         }
 
         #endregion

--- a/sim6502tests/StackPointerWrappingTests.cs
+++ b/sim6502tests/StackPointerWrappingTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using sim6502.Proc;
+using Xunit;
+
+namespace sim6502tests;
+
+public class StackPointerWrappingTests
+{
+    [Fact]
+    public void StackPointer_WrapsCorrectly_WhenDecrementedBelowZero()
+    {
+        var proc = new Processor(ProcessorType.MOS6502);
+        proc.Reset();
+
+        proc.StackPointer = 0x00;
+        proc.StackPointer--;
+
+        proc.StackPointer.Should().Be(0xFF,
+            "SP should wrap from 0x00 to 0xFF on decrement");
+    }
+
+    [Fact]
+    public void StackPointer_WrapsCorrectly_WhenIncrementedAboveFF()
+    {
+        var proc = new Processor(ProcessorType.MOS6502);
+        proc.Reset();
+
+        proc.StackPointer = 0xFF;
+        proc.StackPointer++;
+
+        proc.StackPointer.Should().Be(0x00,
+            "SP should wrap from 0xFF to 0x00 on increment");
+    }
+
+    [Fact]
+    public void StackPointer_MasksLargeValues()
+    {
+        var proc = new Processor(ProcessorType.MOS6502);
+        proc.Reset();
+
+        proc.StackPointer = 0x1FF;
+        proc.StackPointer.Should().Be(0xFF);
+
+        proc.StackPointer = 0x300;
+        proc.StackPointer.Should().Be(0x00);
+
+        proc.StackPointer = 0x44F6;
+        proc.StackPointer.Should().Be(0xF6,
+            "large values should be masked to low byte");
+    }
+
+    [Fact]
+    public void StackPointer_MasksNegativeValues()
+    {
+        var proc = new Processor(ProcessorType.MOS6502);
+        proc.Reset();
+
+        proc.StackPointer = -1;
+        proc.StackPointer.Should().Be(0xFF);
+
+        proc.StackPointer = -256;
+        proc.StackPointer.Should().Be(0x00);
+    }
+
+    [Fact]
+    public void Stack_DoesNotCorruptMemory_DuringLongLoop()
+    {
+        var proc = new Processor(ProcessorType.MOS6502);
+        proc.Reset();
+
+        // Place sentinel values in memory outside the stack region ($0100-$01FF)
+        var sentinelAddr = 0x44F6;
+        byte sentinelValue = 0xA5; // LDA zp opcode — the value from issue #5
+        proc.WriteMemoryValueWithoutIncrement(sentinelAddr, sentinelValue);
+
+        // Simulate 2000+ push/pull cycles (more than InitZobristTables' 1536)
+        proc.StackPointer = 0xFF;
+        for (var i = 0; i < 2000; i++)
+        {
+            // PHA: write to stack, decrement SP
+            proc.WriteMemoryValueWithoutIncrement(proc.StackPointer + 0x100, (byte)(i & 0xFF));
+            proc.StackPointer--;
+
+            // PLA: increment SP, read from stack
+            proc.StackPointer++;
+            proc.ReadMemoryValueWithoutCycle(proc.StackPointer + 0x100);
+        }
+
+        proc.ReadMemoryValueWithoutCycle(sentinelAddr).Should().Be(sentinelValue,
+            "stack operations must not corrupt memory outside the $0100-$01FF stack region");
+    }
+
+    [Fact]
+    public void JSR_RTS_DeepNesting_DoesNotCorruptMemory()
+    {
+        var proc = new Processor(ProcessorType.MOS6502);
+        proc.Reset();
+
+        // Place sentinel in memory that could be hit by corrupted SP
+        proc.WriteMemoryValueWithoutIncrement(0x44F6, 0xA5);
+
+        // Simulate deeply nested JSR stack usage:
+        // Each JSR pushes 2 bytes, so 128 nested JSRs = 256 stack bytes = full wrap
+        proc.StackPointer = 0xFF;
+        for (var i = 0; i < 130; i++)
+        {
+            // Simulate JSR: push return address high then low byte
+            proc.WriteMemoryValueWithoutIncrement(proc.StackPointer + 0x100, (byte)((0x0200 >> 8) & 0xFF));
+            proc.StackPointer--;
+            proc.WriteMemoryValueWithoutIncrement(proc.StackPointer + 0x100, (byte)(0x0200 & 0xFF));
+            proc.StackPointer--;
+        }
+
+        // SP should have wrapped properly and stayed in range
+        proc.StackPointer.Should().BeInRange(0x00, 0xFF);
+
+        // Memory outside stack must be untouched
+        proc.ReadMemoryValueWithoutCycle(0x44F6).Should().Be(0xA5,
+            "deeply nested JSRs must not corrupt memory outside the stack region");
+    }
+}


### PR DESCRIPTION
## Summary
- **Fix stack pointer wrapping** (#5): Replace conditional subtraction with bitwise AND (`value & 0xFF`) to prevent memory corruption during long-running loops. The old logic only handled single overflow — after 1500+ iterations the SP could escape the 0x00-0xFF range and write to arbitrary memory, causing spurious "unsupported opcode" errors like the reported 0x5A (PHY) at $44F6.
- **Add ARM64 Docker support** (#8): Switch from Kaniko to `woodpeckerci/plugin-docker-buildx` for multi-platform builds (linux/amd64 + linux/arm64). Eliminates Rosetta/QEMU emulation issues on Apple Silicon.

Fixes #5
Closes #8

## Test plan
- [x] 6 new stack pointer wrapping tests covering: underflow, overflow, large values, negative values, long loop memory corruption, deep JSR nesting
- [x] Full test suite passes (1341 + 26 = 1367 tests, 0 failures)
- [ ] Verify Woodpecker CI builds multi-arch Docker image after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)