### PR TITLE
fix: use Kaniko for multi-arch Docker builds without privileged mode

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -107,37 +107,87 @@ steps:
         gh release upload "$VERSION" ./release-assets/*.zip --clobber
     depends_on: [release]
 
-  - name: docker-prep
-    image: alpine
+  - name: docker-amd64
+    image: gcr.io/kaniko-project/executor:debug
     when:
       - evaluate: 'CI_COMMIT_MESSAGE not contains "chore(version):"'
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
     commands:
-      - apk add --no-cache wget sed
       - |
         VERSION=$(wget -qO- https://api.github.com/repos/barryw/sim6502/releases/latest | sed -n 's/.*"tag_name".*"v\([^"]*\)".*/\1/p')
         if [ -z "$VERSION" ]; then
           echo "No release found — skipping Docker build"
           exit 0
         fi
-        echo "Building Docker image for v$VERSION"
+        echo "Building amd64 image for v$VERSION"
         sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
         sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
         sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
-        printf "v%s,latest" "$VERSION" > .tags
+        mkdir -p /kaniko/.docker
+        echo "{\"auths\":{\"ghcr.io\":{\"username\":\"barryw\",\"password\":\"$GITHUB_TOKEN\"}}}" > /kaniko/.docker/config.json
+        /kaniko/executor \
+          --context="$CI_WORKSPACE" \
+          --dockerfile="$CI_WORKSPACE/Dockerfile" \
+          --customPlatform=linux/amd64 \
+          --destination="ghcr.io/barryw/sim6502:v$${VERSION}-amd64"
     depends_on: [release]
 
-  - name: docker
-    image: woodpeckerci/plugin-docker-buildx:5
-    privileged: true
+  - name: docker-arm64
+    image: gcr.io/kaniko-project/executor:debug
     when:
       - evaluate: 'CI_COMMIT_MESSAGE not contains "chore(version):"'
-    settings:
-      repo: ghcr.io/barryw/sim6502
-      registry: ghcr.io
-      username: barryw
-      password:
+    environment:
+      GITHUB_TOKEN:
         from_secret: github_token
-      platforms: linux/amd64,linux/arm64
-      auto_tag: false
-      tags_file: .tags
-    depends_on: [docker-prep]
+    commands:
+      - |
+        VERSION=$(wget -qO- https://api.github.com/repos/barryw/sim6502/releases/latest | sed -n 's/.*"tag_name".*"v\([^"]*\)".*/\1/p')
+        if [ -z "$VERSION" ]; then
+          echo "No release found — skipping Docker build"
+          exit 0
+        fi
+        echo "Building arm64 image for v$VERSION"
+        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
+        sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
+        sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
+        mkdir -p /kaniko/.docker
+        echo "{\"auths\":{\"ghcr.io\":{\"username\":\"barryw\",\"password\":\"$GITHUB_TOKEN\"}}}" > /kaniko/.docker/config.json
+        /kaniko/executor \
+          --context="$CI_WORKSPACE" \
+          --dockerfile="$CI_WORKSPACE/Dockerfile" \
+          --customPlatform=linux/arm64 \
+          --destination="ghcr.io/barryw/sim6502:v$${VERSION}-arm64"
+    depends_on: [release]
+
+  - name: docker-manifest
+    image: mplatform/manifest-tool:alpine
+    when:
+      - evaluate: 'CI_COMMIT_MESSAGE not contains "chore(version):"'
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - |
+        VERSION=$(wget -qO- https://api.github.com/repos/barryw/sim6502/releases/latest | sed -n 's/.*"tag_name".*"v\([^"]*\)".*/\1/p')
+        if [ -z "$VERSION" ]; then
+          echo "No release found — skipping manifest"
+          exit 0
+        fi
+        echo "Creating multi-arch manifest for v$VERSION"
+        manifest-tool \
+          --username barryw \
+          --password "$GITHUB_TOKEN" \
+          push from-args \
+          --platforms linux/amd64,linux/arm64 \
+          --template "ghcr.io/barryw/sim6502:v$${VERSION}-ARCH" \
+          --target "ghcr.io/barryw/sim6502:v$${VERSION}"
+        manifest-tool \
+          --username barryw \
+          --password "$GITHUB_TOKEN" \
+          push from-args \
+          --platforms linux/amd64,linux/arm64 \
+          --template "ghcr.io/barryw/sim6502:v$${VERSION}-ARCH" \
+          --target "ghcr.io/barryw/sim6502:latest"
+    depends_on: [docker-amd64, docker-arm64]


### PR DESCRIPTION
## Summary
- Replace the privileged `woodpeckerci/plugin-docker-buildx` with two Kaniko builds (amd64 + arm64) plus `manifest-tool` for multi-arch manifest creation
- No privileged mode required — Kaniko builds container images without a Docker daemon

## How it works
1. `docker-amd64`: Kaniko builds with `--customPlatform=linux/amd64`, pushes `v{version}-amd64` tag
2. `docker-arm64`: Kaniko builds with `--customPlatform=linux/arm64`, pushes `v{version}-arm64` tag
3. `docker-manifest`: `manifest-tool` combines both into `v{version}` and `latest` multi-arch manifests

## Test plan
- [ ] Verify Woodpecker CI pipeline passes linting (no privileged mode)
- [ ] Verify both arch images build and push
- [ ] Verify `docker manifest inspect ghcr.io/barryw/sim6502:latest` shows both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)