### PR TITLE
fix: use pre-built output for multi-arch Docker builds

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -107,6 +107,23 @@ steps:
         gh release upload "$VERSION" ./release-assets/*.zip --clobber
     depends_on: [release]
 
+  - name: docker-publish
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    when:
+      - evaluate: 'CI_COMMIT_MESSAGE not contains "chore(version):"'
+    commands:
+      - |
+        VERSION=$(wget -qO- https://api.github.com/repos/barryw/sim6502/releases/latest | sed -n 's/.*"tag_name".*"v\([^"]*\)".*/\1/p')
+        if [ -z "$VERSION" ]; then
+          echo "No release found — skipping Docker publish"
+          exit 0
+        fi
+        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
+        sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
+        sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
+        dotnet publish sim6502/sim6502.csproj -c Release -o docker-publish
+    depends_on: [release]
+
   - name: docker-amd64
     image: gcr.io/kaniko-project/executor:debug
     when:
@@ -121,18 +138,14 @@ steps:
           echo "No release found — skipping Docker build"
           exit 0
         fi
-        echo "Building amd64 image for v$VERSION"
-        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
-        sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
-        sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
         mkdir -p /kaniko/.docker
         echo "{\"auths\":{\"ghcr.io\":{\"username\":\"barryw\",\"password\":\"$GITHUB_TOKEN\"}}}" > /kaniko/.docker/config.json
         /kaniko/executor \
           --context="$CI_WORKSPACE" \
-          --dockerfile="$CI_WORKSPACE/Dockerfile" \
-          --customPlatform=linux/amd64 \
+          --dockerfile="$CI_WORKSPACE/Dockerfile.runtime" \
+          --custom-platform=linux/amd64 \
           --destination="ghcr.io/barryw/sim6502:v$${VERSION}-amd64"
-    depends_on: [release]
+    depends_on: [docker-publish]
 
   - name: docker-arm64
     image: gcr.io/kaniko-project/executor:debug
@@ -148,18 +161,14 @@ steps:
           echo "No release found — skipping Docker build"
           exit 0
         fi
-        echo "Building arm64 image for v$VERSION"
-        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" sim6502/sim6502.csproj
-        sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>$VERSION.0</AssemblyVersion>|" sim6502/sim6502.csproj
-        sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>$VERSION.0</FileVersion>|" sim6502/sim6502.csproj
         mkdir -p /kaniko/.docker
         echo "{\"auths\":{\"ghcr.io\":{\"username\":\"barryw\",\"password\":\"$GITHUB_TOKEN\"}}}" > /kaniko/.docker/config.json
         /kaniko/executor \
           --context="$CI_WORKSPACE" \
-          --dockerfile="$CI_WORKSPACE/Dockerfile" \
-          --customPlatform=linux/arm64 \
+          --dockerfile="$CI_WORKSPACE/Dockerfile.runtime" \
+          --custom-platform=linux/arm64 \
           --destination="ghcr.io/barryw/sim6502:v$${VERSION}-arm64"
-    depends_on: [release]
+    depends_on: [docker-publish]
 
   - name: docker-manifest
     image: mplatform/manifest-tool:alpine

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,9 @@
+# Packaging-only Dockerfile for multi-arch builds.
+# Expects pre-built framework-dependent output in docker-publish/.
+# No RUN commands, so Kaniko --customPlatform works on any host.
+FROM mcr.microsoft.com/dotnet/runtime:10.0
+
+WORKDIR /app
+COPY docker-publish/ .
+
+ENTRYPOINT ["dotnet", "Sim6502TestRunner.dll"]


### PR DESCRIPTION
## Summary
Fix the arm64 Docker build failure (`exec format error`). Kaniko's `--custom-platform` pulls the target arch's base image but can't execute RUN commands for a foreign architecture on an amd64 host.

**Solution:** Pre-build .NET app on amd64 (framework-dependent output is architecture-neutral IL), then use Kaniko with a COPY-only `Dockerfile.runtime` for each platform. No RUN commands = no cross-arch execution needed.

**Pipeline flow:**
1. `docker-publish` — `dotnet publish` on amd64 SDK → `docker-publish/`
2. `docker-amd64` — Kaniko + `Dockerfile.runtime` + `--custom-platform=linux/amd64`
3. `docker-arm64` — Kaniko + `Dockerfile.runtime` + `--custom-platform=linux/arm64`
4. `docker-manifest` — manifest-tool combines into `v{version}` and `latest` tags

## Test plan
- [ ] Woodpecker pipeline passes without privileged mode
- [ ] Both amd64 and arm64 images push to ghcr.io
- [ ] `docker manifest inspect ghcr.io/barryw/sim6502:latest` shows both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)